### PR TITLE
Fixed issue wherein reordering a collection did not work

### DIFF
--- a/gaedo-blueprints/src/main/java/com/dooapp/gaedo/blueprints/BluePrintsPersister.java
+++ b/gaedo-blueprints/src/main/java/com/dooapp/gaedo/blueprints/BluePrintsPersister.java
@@ -31,13 +31,8 @@ import com.tinkerpop.blueprints.pgm.Vertex;
 
 public class BluePrintsPersister {
     private static final Logger logger = Logger.getLogger(BluePrintsPersister.class.getName());
-    /**
-     * Node kind used by this updater
-     */
-    private Kind nodeKind;
 
     public BluePrintsPersister(Kind node) {
-        nodeKind = node;
     }
 
 
@@ -331,30 +326,37 @@ public class BluePrintsPersister {
         // As a convention, null values are never stored
         if (value != null /* && value.size()>0 that case precisely created https://github.com/Riduidel/gaedo/issues/13 */) {
             // Get previously existing vertices
-            Iterable<Edge> existingIterator = service.getStrategy().getOutEdgesFor(rootVertex, p);
-            // Do not change previously existing vertices if they correspond to new ones
-            // Which is done in that call : as vertex is always looked up before creation, there is little duplication risk
-            // or at elast that risk should be covered by selected Blueprints implementation
-            Collection<Vertex> newVertices = createCollectionVerticesFor(service, value, cascade, objectsBeingAccessed);
-            Map<Vertex, Edge> oldVertices = new HashMap<Vertex, Edge>();
-            for (Edge e : existingIterator) {
+            Iterable<Edge> existingEdges = service.getStrategy().getOutEdgesFor(rootVertex, p);
+            // Get the new, updated Collection of vertices
+            Collection<Vertex> allVertices = createCollectionVerticesFor(service, value, cascade, objectsBeingAccessed);
+            // Keep track of the edges that correspond to the vertices
+            Map<Vertex, Edge> allEdges = new HashMap<Vertex, Edge>();
+            // ...and put the old, invalid vertices aside for later 
+            Set<Edge> edgesToRemove = new HashSet<Edge>();
+            
+            for (Edge e : existingEdges) {
                 Vertex inVertex = e.getInVertex();
-                if (newVertices.contains(inVertex)) {
-                    newVertices.remove(inVertex);
+                if (allVertices.contains(inVertex)) {
+                    allEdges.put(inVertex, e);
                 } else {
-                    oldVertices.put(inVertex, e);
+                    edgesToRemove.add(e);
+                    allEdges.put(inVertex, null);
                 }
             }
-            // Now the have been collected, remove all old vertices
-            for (Map.Entry<Vertex, Edge> entry : oldVertices.entrySet()) {
-                database.removeEdge(entry.getValue());
+            
+            // First, delete the old ones
+            for (Edge edge : edgesToRemove) {
+                database.removeEdge(edge);
             }
-            // And finally add new vertices
+            
+            // Then, go through the updated Vertices. Create edges if necessary, then always set the order property.
             int order = 0;
-            for (Vertex newVertex : newVertices) {
-                Edge createdEdge = service.getDriver().createEdgeFor(rootVertex, newVertex, p);
+            for (Vertex vertex : allVertices) {
+            	Edge edgeForVertex = allEdges.get(vertex);
+            	if(edgeForVertex == null)
+            		edgeForVertex = service.getDriver().createEdgeFor(rootVertex, vertex, p);
                 // Add a fancy-schmancy property to maintain order in this town
-                createdEdge.setProperty(Properties.collection_index.name(), order++);
+                edgeForVertex.setProperty(Properties.collection_index.name(), order++);
             }
         }
     }

--- a/gaedo-blueprints/src/test/java/com/dooapp/gaedo/blueprints/OrderedCollectionTest.java
+++ b/gaedo-blueprints/src/test/java/com/dooapp/gaedo/blueprints/OrderedCollectionTest.java
@@ -3,7 +3,6 @@ package com.dooapp.gaedo.blueprints;
 import static com.dooapp.gaedo.blueprints.TestUtils.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertThat;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -80,13 +79,11 @@ public class OrderedCollectionTest extends AbstractGraphTest {
 		User user = getACopyOfTheAuthor();
 		
 		// ...and make sure that the posts are in the correct order
-		assertThat("Make sure we got the right number of posts", user.posts.size(), is(6));
-		assertThat("First post is in correct position", user.posts.get(0), is(posts.get(5)));
-		assertThat("Second post is in correct position", user.posts.get(1), is(posts.get(4)));
-		assertThat("Third post is in correct position", user.posts.get(2), is(posts.get(3)));
-		assertThat("Fourth post is in correct position", user.posts.get(3), is(posts.get(2)));
-		assertThat("Fifth post is in correct position", user.posts.get(4), is(posts.get(1)));
-		assertThat("Sixth post is in correct position", user.posts.get(5), is(posts.get(0)));
+		final int NUM_POSTS = 6;
+		assertThat("Make sure we got the right number of posts", user.posts.size(), is(NUM_POSTS));
+		for(int i=0; i<NUM_POSTS; i++) {
+			assertThat("Post " + i + " is in correct position", user.posts.get(i), is(posts.get(NUM_POSTS - i - 1)));
+		}
 	}
 	
 	@Test
@@ -115,6 +112,10 @@ public class OrderedCollectionTest extends AbstractGraphTest {
 		assertThat("fourth post is in correct position", user.posts.get(3), is(posts.get(0)));
 	}
 	
+	/**
+	 * Load this.author fresh from the database, by building a query to fetch it.
+	 * @return
+	 */
 	private User getACopyOfTheAuthor() {
 		User user = getUserService().find().matching(new QueryBuilder<UserInformer>() {
 
@@ -184,5 +185,25 @@ public class OrderedCollectionTest extends AbstractGraphTest {
 		assertThat("Fourth post is in correct position", user.posts.get(3), is(posts.get(3)));
 		assertThat("Fifth post is in correct position", user.posts.get(4), is(posts.get(4)));
 		assertThat("Sixth post is in correct position", user.posts.get(5), is(posts.get(5)));
+	}
+	
+	@Test
+	public void testReorderingListOnUpdateIsCorrectlySaved() {
+		// Just setup the author with all the posts
+		for(Post p : posts)
+			author.posts.add(p);
+		getUserService().update(author);
+		
+		// Now, switch the order of the first and second post...
+		author.posts.clear();
+		author.posts.add(posts.get(1));
+		author.posts.add(posts.get(0));
+		for(int i=2; i<posts.size(); i++)
+			author.posts.add(posts.get(i));
+		getUserService().update(author);
+		
+		// ...and make sure that it actually worked.
+		User authorCopy = getACopyOfTheAuthor();
+		assertThat("Successfully re-ordered the list of posts", authorCopy.posts, is(author.posts));
 	}
 }


### PR DESCRIPTION
If the user re-orders a Collection, but does not change any elements, then updating the Collection has no effect (and the old order is preserved).
