### PR TITLE
Better handling of collection reordering (with doubles)

### DIFF
--- a/gaedo-blueprints/src/test/java/com/dooapp/gaedo/blueprints/OrderedCollectionTest.java
+++ b/gaedo-blueprints/src/test/java/com/dooapp/gaedo/blueprints/OrderedCollectionTest.java
@@ -211,4 +211,28 @@ public class OrderedCollectionTest extends AbstractGraphTest {
 		User authorCopy = getACopyOfTheAuthor();
 		assertThat("Successfully re-ordered the list of posts", authorCopy.posts, is(author.posts));
 	}
+	
+	/**
+	 * This time, the list has doubles of some elements!
+	 */
+	@Test
+	public void testReorderingListWithDoubles() {
+		// Setup: add each post TWICE!
+		for(Post p : posts) {
+			author.posts.add(p);
+			author.posts.add(p);
+		}
+		getUserService().update(author);
+		
+		// Now, reorder. Instead of 112233, make it 123123.
+		author.posts.clear();
+		for(int i=0; i<2; i++)
+			for(Post p : posts)
+				author.posts.add(p);
+		getUserService().update(author);
+		
+		// And finally, make sure that it worked.
+		User authorCopy = getACopyOfTheAuthor();
+		assertThat("Successfully re-ordered the list of posts (with doubles!)", authorCopy.posts, is(author.posts));
+	}
 }


### PR DESCRIPTION
Fixed another issue with re-ordering collections: BluePrintsPersister#updateCollection did not properly handle Collections with doubles of some values. The result was both incorrect ordering (the same Edge was used multiple times), and "Edge leak" (since the doubles of an existing Edge were not deleted).
